### PR TITLE
Add relationship between posts and categories

### DIFF
--- a/database/migrations/2017_09_11_100246_create_post_categories_table.php
+++ b/database/migrations/2017_09_11_100246_create_post_categories_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePostCategoriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts_categories', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('post_id');
+            $table->integer('category_id');
+        });
+    }
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('posts_categories');
+    }
+}

--- a/src/Category.php
+++ b/src/Category.php
@@ -28,6 +28,9 @@ class Category extends Model implements StoryCategory
      */
     public function post()
     {
-        return $this->hasMany(Post::class);
+        return $this->belongsToMany(
+            resolve(Contracts\StoryPost::class),
+            'posts_categories', 'category_id', 'post_id'
+        );
     }
 }

--- a/src/Post.php
+++ b/src/Post.php
@@ -38,4 +38,17 @@ class Post extends Model implements StoryPost
     {
         return $this->belongsTo(resolve(Contracts\StoryUser::class));
     }
+
+    /**
+     * Get all categories relationship
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function category()
+    {
+        return $this->belongsToMany(
+            resolve(Contracts\StoryCategory::class),
+            'posts_categories', 'post_id', 'category_id'
+        );
+    }
 }


### PR DESCRIPTION
With this pull request, we can set relationship post with category. 

Example how you can attach relationship

```
$categories = $request->input('categories) // category_id array [1, 2, 3]

$post = resolve(\Story\Cms\Contracts\StoryPost)::create($data);
$post->category()->sync($categories);
```
